### PR TITLE
3B-G09-W001-PR01. Use Import Path Aliases

### DIFF
--- a/app/api/admin/ai/analytics/route.ts
+++ b/app/api/admin/ai/analytics/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { requireAdmin } from "../../../../../lib/admin/auth/roleGuard";
-import { sendToGemini } from "../../../../../lib/admin/ai/gemini";
+import { requireAdmin } from "@/lib/admin/auth/roleGuard";
+import { sendToGemini } from "@/lib/admin/ai/gemini";
 
 function toErrorResponse(error: unknown) {
   if (error instanceof Error && error.name === "AdminAuthorizationError") {

--- a/app/api/admin/auth/google/route.ts
+++ b/app/api/admin/auth/google/route.ts
@@ -4,8 +4,8 @@ import {
   buildSessionPayload,
   getGoogleSsoConfig,
   isAllowedGoogleEmail,
-} from "../../../../../lib/admin/auth/authOptions";
-import { findUserByEmail } from "../../../../../lib/admin/db/users";
+} from "@/lib/admin/auth/authOptions";
+import { findUserByEmail } from "@/lib/admin/db/users";
 
 /**
  * Handles Google SSO registration checks before creating an admin session payload.

--- a/app/api/admin/auth/login/route.ts
+++ b/app/api/admin/auth/login/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { buildSessionPayload } from "../../../../../lib/admin/auth/authOptions";
-import { loginUser } from "../../../../../lib/admin/db/users";
+import { buildSessionPayload } from "@/lib/admin/auth/authOptions";
+import { loginUser } from "@/lib/admin/db/users";
 
 function toErrorResponse(error: unknown) {
   if (error instanceof Error && error.name === "AuthenticationError") {

--- a/app/api/admin/auth/register/route.ts
+++ b/app/api/admin/auth/register/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { registerUser } from "../../../../../lib/admin/db/users";
+import { registerUser } from "@/lib/admin/db/users";
 
 function toErrorResponse(error: unknown) {
   if (error instanceof Error && error.name === "ValidationError") {

--- a/app/api/admin/certificates/[id]/route.ts
+++ b/app/api/admin/certificates/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { requireAdmin } from "../../../../../lib/admin/auth/roleGuard";
-import { toggleAttendeeStatus } from "../../../../../lib/admin/db/certificates";
+import { requireAdmin } from "@/lib/admin/auth/roleGuard";
+import { toggleAttendeeStatus } from "@/lib/admin/db/certificates";
 
 function toErrorResponse(error: unknown) {
   if (error instanceof Error && error.name === "AdminAuthorizationError") {

--- a/app/api/admin/certificates/route.ts
+++ b/app/api/admin/certificates/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { requireAdmin } from "../../../../lib/admin/auth/roleGuard";
-import { getAttendeesByEvent } from "../../../../lib/admin/db/certificates";
+import { requireAdmin } from "@/lib/admin/auth/roleGuard";
+import { getAttendeesByEvent } from "@/lib/admin/db/certificates";
 
 function toErrorResponse(error: unknown) {
   if (error instanceof Error && error.name === "AdminAuthorizationError") {

--- a/app/api/admin/dashboard/route.ts
+++ b/app/api/admin/dashboard/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
-import { requireAdmin } from "../../../../lib/admin/auth/roleGuard";
-import { sendToGemini } from "../../../../lib/admin/ai/gemini";
+import { requireAdmin } from "@/lib/admin/auth/roleGuard";
+import { sendToGemini } from "@/lib/admin/ai/gemini";
 import {
   getDashboardAttendanceData,
   getDashboardCharts,
   getDashboardStats,
-} from "../../../../lib/admin/db/dashboard";
+} from "@/lib/admin/db/dashboard";
 
 function toErrorResponse(error: unknown) {
   if (error instanceof Error && error.name === "AdminAuthorizationError") {

--- a/app/api/admin/events/[id]/route.ts
+++ b/app/api/admin/events/[id]/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { requireAdmin } from "../../../../../lib/admin/auth/roleGuard";
+import { requireAdmin } from "@/lib/admin/auth/roleGuard";
 import {
   getEventById,
   postAdminComment,
   updateEventStatus,
-} from "../../../../../lib/admin/db/events";
+} from "@/lib/admin/db/events";
 
 function toErrorResponse(error: unknown) {
   if (error instanceof Error && error.name === "AdminAuthorizationError") {

--- a/app/api/admin/events/route.ts
+++ b/app/api/admin/events/route.ts
@@ -1,7 +1,7 @@
-import { NextResponse } from "next/server";
+"app/api/admin/events/[id]/route.ts" \import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { requireAdmin } from "../../../../lib/admin/auth/roleGuard";
-import { getEvents } from "../../../../lib/admin/db/events";
+import { requireAdmin } from "@/lib/admin/auth/roleGuard";
+import { getEvents } from "@/lib/admin/db/events";
 
 function toErrorResponse(error: unknown) {
   if (error instanceof Error && error.name === "AdminAuthorizationError") {

--- a/app/api/admin/feedback/route.ts
+++ b/app/api/admin/feedback/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { requireAdmin } from "../../../../lib/admin/auth/roleGuard";
-import { getFeedbackOverview } from "../../../../lib/admin/db/feedback";
+import { requireAdmin } from "@/lib/admin/auth/roleGuard";
+import { getFeedbackOverview } from "@/lib/admin/db/feedback";
 
 function toErrorResponse(error: unknown) {
   if (error instanceof Error && error.name === "AdminAuthorizationError") {

--- a/app/api/admin/notifications/route.ts
+++ b/app/api/admin/notifications/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { requireAdmin } from "../../../../lib/admin/auth/roleGuard";
-import { getNotifications } from "../../../../lib/admin/db/notifications";
+import { requireAdmin } from "@/lib/admin/auth/roleGuard";
+import { getNotifications } from "@/lib/admin/db/notifications";
 
 function toErrorResponse(error: unknown) {
   if (error instanceof Error && error.name === "AdminAuthorizationError") {

--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { requireAdmin } from "../../../../../lib/admin/auth/roleGuard";
+import { requireAdmin } from "@/lib/admin/auth/roleGuard";
 import {
   assignToEvent,
   deleteUser,
   resetUserPassword,
   toggleUserStatus,
   updateUser,
-} from "../../../../../lib/admin/db/users";
+} from "@/lib/admin/db/users";
 
 function toErrorResponse(error: unknown) {
   if (error instanceof Error && error.name === "AdminAuthorizationError") {

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { requireAdmin } from "../../../../lib/admin/auth/roleGuard";
-import { createUser, getUsers } from "../../../../lib/admin/db/users";
+import { requireAdmin } from "@/lib/admin/auth/roleGuard";
+import { createUser, getUsers } from "@/lib/admin/db/users";
 
 function toErrorResponse(error: unknown) {
   if (error instanceof Error && error.name === "AdminAuthorizationError") {

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,5 @@
 import NextAuth from "next-auth";
-import { authOptions } from "../../../../lib/admin/auth/authOptions";
+import { authOptions } from "@/lib/admin/auth/authOptions";
 
 const handler = NextAuth(authOptions);
 


### PR DESCRIPTION
## Summary
- It changes import lines in some API route files so they use @/lib/... instead of very long paths with many ../ (for example ../../../../lib/...).
- So the code is easier to read and matches the issue about using import path aliases (Next.js style with @/).

## Changes
- Updated imports in app/api routes that pointed to `lib/`` with deep relative paths.
- Switched them to @/lib/... (same folders under lib/, just a cleaner import).
- tsconfig.json already had the @/ alias, so no config change was required.

## Checklist
- [x]  @/lib/... paths match the old lib/... targets (no wrong file paths).
- [x]  Checked that those imports now use @/lib/....
- [x]  Confirmed only app/api/** route files were changed for this issue.