### PR TITLE
3B-G09-W006-PR01. Configure 404 Not Found Page

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import "@/styles/pages/not-found.css";
 
 export const metadata: Metadata = {
@@ -17,6 +18,11 @@ export default function NotFound() {
           We couldn&apos;t find that page
         </h1>
         <p className="not-found__lede">The link may be broken or the page was removed.</p>
+        <div className="not-found__actions">
+          <Link href="/" className="not-found__btn">
+            Back to home
+          </Link>
+        </div>
       </div>
     </section>
   );

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import "@/styles/pages/not-found.css";
+
+export const metadata: Metadata = {
+  title: "Page not found — DC Space",
+  description: "This page could not be found.",
+};
+
+export default function NotFound() {
+  return (
+    <section className="not-found" aria-labelledby="not-found-heading">
+      <div className="not-found__inner">
+        <p className="not-found__code" aria-hidden="true">
+          404
+        </p>
+        <h1 id="not-found-heading" className="not-found__title">
+          We couldn&apos;t find that page
+        </h1>
+        <p className="not-found__lede">The link may be broken or the page was removed.</p>
+      </div>
+    </section>
+  );
+}

--- a/styles/pages/not-found.css
+++ b/styles/pages/not-found.css
@@ -1,0 +1,44 @@
+/* 404 — full-viewport, no app shell; uses root body gradient + DC Space palette */
+
+.not-found {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--main-pad-y) var(--main-pad-x);
+  min-height: 100dvh;
+  min-height: 100vh;
+}
+
+.not-found__inner {
+  width: min(520px, 100%);
+  text-align: center;
+}
+
+.not-found__code {
+  font-family: var(--font-display), "Montserrat", system-ui, sans-serif;
+  font-size: clamp(4rem, 12vw, 6.5rem);
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.04em;
+  color: var(--nav-active);
+  text-shadow: 0 3px 0 rgba(92, 136, 229, 0.22);
+  margin: 0 0 8px;
+}
+
+.not-found__title {
+  font-family: var(--font-display), "Montserrat", system-ui, sans-serif;
+  font-size: clamp(1.35rem, 3.2vw, 1.75rem);
+  font-weight: 700;
+  color: var(--brown-icon);
+  margin: 0 0 14px;
+  line-height: 1.25;
+}
+
+.not-found__lede {
+  font-family: var(--font), sans-serif;
+  font-size: 1.05rem;
+  line-height: 1.55;
+  color: rgba(42, 33, 24, 0.78);
+  margin: 0 auto;
+  max-width: 38ch;
+}

--- a/styles/pages/not-found.css
+++ b/styles/pages/not-found.css
@@ -39,6 +39,37 @@
   font-size: 1.05rem;
   line-height: 1.55;
   color: rgba(42, 33, 24, 0.78);
-  margin: 0 auto;
+  margin: 0 auto 28px;
   max-width: 38ch;
+}
+
+.not-found__actions {
+  display: flex;
+  justify-content: center;
+}
+
+.not-found__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 46px;
+  padding: 0 24px;
+  border-radius: var(--card-radius);
+  font-family: var(--font-ui), "Poppins", system-ui, sans-serif;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border: 2px solid var(--btn-gold-border);
+  background: linear-gradient(180deg, var(--btn-gold) 0%, #d4b24f 100%);
+  color: var(--btn-brown);
+  box-shadow: 0 2px 0 var(--brown-shadow);
+}
+
+.not-found__btn:hover {
+  filter: brightness(1.04);
+  box-shadow: 0 3px 8px rgba(60, 40, 28, 0.2);
+}
+
+.not-found__btn:focus-visible {
+  outline: 2px solid var(--nav-active);
+  outline-offset: 3px;
 }


### PR DESCRIPTION
**Summary**

- Implements a global 404 Not Found page for the Next.js App Router so unknown routes show a clear, on-brand error state instead of a generic or broken view.


**What changed**

- Added app/not-found.tsx — global not-found UI with page metadata (Page not found — DC Space).
- Added styles/pages/not-found.css — layout and typography aligned with DC Space (display type for 404, brown headline, supporting copy on the existing cream gradient from the root layout).